### PR TITLE
fix: update pubspec

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -6,7 +6,7 @@ void main() {
 }
 
 class MyApp extends StatelessWidget {
-  const MyApp({super.key});
+  const MyApp({Key? key}) : super(key: key);
 
   @override
   Widget build(BuildContext context) {
@@ -23,7 +23,7 @@ class MyApp extends StatelessWidget {
 }
 
 class IToast extends StatelessWidget {
-  const IToast({super.key});
+  const IToast({Key? key}) : super(key: key);
 
   @override
   Widget build(BuildContext context) {

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -216,5 +216,5 @@ packages:
     source: hosted
     version: "13.0.0"
 sdks:
-  dart: ">=3.3.1 <4.0.0"
+  dart: ">=3.2.0-0 <4.0.0"
   flutter: ">=1.17.0"

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -1,19 +1,15 @@
 name: example
 description: "A new Flutter project."
-
 publish_to: 'none' # Remove this line if you wish to publish to pub.dev
-
 
 version: 1.0.0+1
 
 environment:
-  sdk: '>=3.3.1 <4.0.0'
-
+  sdk: ">=2.15.0 <4.0.0"
 
 dependencies:
   flutter:
     sdk: flutter
-
   cupertino_icons: ^1.0.6
 
   i_toast:
@@ -22,13 +18,9 @@ dependencies:
 dev_dependencies:
   flutter_test:
     sdk: flutter
-
   flutter_lints: ^3.0.0
 
-
 flutter:
-
-
   uses-material-design: true
 
   

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,8 +1,6 @@
 name: i_toast
 description: >
-  A Flutter package for displaying customizable toast notifications. 
-  Provides easy-to-use and non-intrusive toast messages with options 
-  for customization including duration, position, and appearance.
+  Provides easy-to-use and non-intrusive toast messages with options for customization including duration, position, and appearance.
 version: 0.0.1
 homepage: https://github.com/iwalletmobilecase/i_toast
 repository: https://github.com/iwalletmobilecase/i_toast
@@ -16,7 +14,7 @@ platforms:
   windows:
 
 environment:
-  sdk: ">=2.12.0 <4.0.0"
+  sdk: ">=2.15.0 <4.0.0"
   flutter: ">=1.17.0"
 
 dependencies:
@@ -27,7 +25,3 @@ dev_dependencies:
   flutter_test:
     sdk: flutter
   flutter_lints: ^3.0.0
-
-flutter:
-  assets:
-    - assets/


### PR DESCRIPTION
This pull request is on pub.dev [i_toast](https://pub.dev/packages/i_toast/score) : 

```
0/10 points: Provide a valid pubspec.yaml
The package description is too long.
Search engines display only the first part of the description. Try to keep the value of the description field in your package's pubspec.yaml file between 60 and 180 characters.
```

It was created based on the description.

Additionally, the SDK version has been updated to `2.15.0.`