### PR TITLE
fix: fix dart format

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -27,7 +27,12 @@ class IToast extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final List<ToastType> toastType = [ToastType.error, ToastType.info, ToastType.success, ToastType.warning];
+    final List<ToastType> toastType = [
+      ToastType.error,
+      ToastType.info,
+      ToastType.success,
+      ToastType.warning
+    ];
     return Scaffold(
       appBar: AppBar(
         title: const Text("iToast Example"),
@@ -44,7 +49,8 @@ class IToast extends StatelessWidget {
                 onPressed: () {
                   _showToastMessage(
                     context,
-                    toastType[index].name.substring(0, 1).toUpperCase() + toastType[index].name.substring(1),
+                    toastType[index].name.substring(0, 1).toUpperCase() +
+                        toastType[index].name.substring(1),
                     "${toastType[index].name} subtitle.",
                     toastType[index],
                     leading: const Icon(Icons.info),

--- a/lib/src/constants/string_constant.dart
+++ b/lib/src/constants/string_constant.dart
@@ -4,5 +4,6 @@ import 'package:flutter/material.dart';
 class StringConstant {
   const StringConstant._();
 
-  static const assertMessage = "If the toast type is not custom, you do not need to provide background color and border";
+  static const assertMessage =
+      "If the toast type is not custom, you do not need to provide background color and border";
 }

--- a/lib/src/toast_message/i_toast_service.dart
+++ b/lib/src/toast_message/i_toast_service.dart
@@ -127,7 +127,8 @@ class _ToastMessageWidget extends StatefulWidget {
     this.toastHeight,
     this.onTapTrailing,
   })  : assert(
-          toastType == ToastType.custom || (toastBackgroundColor == null && toastBorder == null),
+          toastType == ToastType.custom ||
+              (toastBackgroundColor == null && toastBorder == null),
           StringConstant.assertMessage,
         ),
         super(key: key);
@@ -137,7 +138,8 @@ class _ToastMessageWidget extends StatefulWidget {
 }
 
 /// State class for the toast message widget.
-class _ToastMessageWidgetState extends State<_ToastMessageWidget> with SingleTickerProviderStateMixin {
+class _ToastMessageWidgetState extends State<_ToastMessageWidget>
+    with SingleTickerProviderStateMixin {
   late AnimationController _animationController;
   late Animation<double> _animationSlide;
   late Animation<double> _animationOpacity;
@@ -149,8 +151,10 @@ class _ToastMessageWidgetState extends State<_ToastMessageWidget> with SingleTic
       vsync: this,
       duration: const Duration(milliseconds: 400),
     );
-    _animationSlide = Tween<double>(begin: -1.0, end: 0.0).animate(_animationController);
-    _animationOpacity = Tween<double>(begin: 0.0, end: 1.0).animate(_animationController);
+    _animationSlide =
+        Tween<double>(begin: -1.0, end: 0.0).animate(_animationController);
+    _animationOpacity =
+        Tween<double>(begin: 0.0, end: 1.0).animate(_animationController);
     _animationController.addStatusListener((status) {
       if (status == AnimationStatus.completed) {
         Future<void>.delayed(widget.duration).then((_) {


### PR DESCRIPTION
This pull request is on pub.dev [i_toast](https://pub.dev/packages/i_toast/score) : 

```
40/50 points: code has no errors, warnings, lints, or formatting issues lib/src/constants/string_constant.dart doesn't match the Dart formatter. To format your files run: dart format . lib/src/toast_message/i_toast_service.dart doesn't match the Dart formatter. To format your files run: dart format .
```
For this reason, `dart format .` from the terminal as written in pub.dev. command has been run.